### PR TITLE
혼잣말 Input의 auto zoom in 현상을 개선(iOS환경 한정), focus기능 추가

### DIFF
--- a/pages/generate/[platformName].tsx
+++ b/pages/generate/[platformName].tsx
@@ -9,7 +9,7 @@ import { RESULT_ROUTES } from '@/constants/route';
 import type { GetStaticPaths, GetStaticProps, NextPage } from 'next';
 import { useRouter } from 'next/router';
 import type { ParsedUrlQuery } from 'querystring';
-import { useState } from 'react';
+import { useRef, useState } from 'react';
 
 interface Params extends ParsedUrlQuery {
   platformName: Platform;
@@ -24,6 +24,8 @@ const GeneratePage: NextPage<GeneratePageProps> = ({ platformName }) => {
   const [currentSnack, setCurrentSnack] = useState<PreviewSnack>(null);
   const [talkMySelf, setTalkMySelf] = useState('');
   const [isVisibleTalkMySelf, setIsVisibleTalkMySelf] = useState(false);
+
+  const talkMySelfRef = useRef<HTMLInputElement>(null);
 
   const selectedOptions = {
     background: currentBackground,
@@ -57,6 +59,7 @@ const GeneratePage: NextPage<GeneratePageProps> = ({ platformName }) => {
           talkMySelf={talkMySelf}
           setTalkMySelf={setTalkMySelf}
           isVisibleTalkMySelf={isVisibleTalkMySelf}
+          ref={talkMySelfRef}
         />
         <ControlSection
           currentBackground={currentBackground}
@@ -65,6 +68,7 @@ const GeneratePage: NextPage<GeneratePageProps> = ({ platformName }) => {
           setCurrentBackground={setCurrentBackground}
           setCurrentSnack={setCurrentSnack}
           setIsVisibleTalkMySelf={setIsVisibleTalkMySelf}
+          talkMySelfRef={talkMySelfRef}
         />
       </GenerateLayout>
     </>

--- a/src/components/generate/CategoryOption/CategoryOption.component.tsx
+++ b/src/components/generate/CategoryOption/CategoryOption.component.tsx
@@ -1,5 +1,5 @@
 import { KeyOf } from '@/types/helper';
-import { Dispatch, SetStateAction } from 'react';
+import { Dispatch, RefObject, SetStateAction } from 'react';
 import BackgroundOptions from '../BackgroundOptions/BackgroundOptions.component';
 import { PreviewBackgroundColor, PreviewSnack } from '../PreviewSection/PreviewSection.component';
 import SnackOptions from '../SnackOptions/SnackOptions.component';
@@ -21,6 +21,7 @@ interface CategoryOptionProps {
   setCurrentBackground: Dispatch<SetStateAction<PreviewBackgroundColor>>;
   setCurrentSnack: Dispatch<SetStateAction<PreviewSnack>>;
   setIsVisibleTalkMySelf: Dispatch<SetStateAction<boolean>>;
+  talkMySelfRef: RefObject<HTMLInputElement>;
 }
 
 const CategoryOption = ({
@@ -31,6 +32,7 @@ const CategoryOption = ({
   setCurrentBackground,
   setCurrentSnack,
   setIsVisibleTalkMySelf,
+  talkMySelfRef,
 }: CategoryOptionProps) => {
   switch (currentCategory) {
     case 'background':
@@ -47,6 +49,7 @@ const CategoryOption = ({
         <TalkMySelfControl
           isVisibleTalkMySelf={isVisibleTalkMySelf}
           setIsVisibleTalkMySelf={setIsVisibleTalkMySelf}
+          talkMySelfRef={talkMySelfRef}
         />
       );
   }

--- a/src/components/generate/ControlSection/ControlSection.component.tsx
+++ b/src/components/generate/ControlSection/ControlSection.component.tsx
@@ -1,5 +1,5 @@
 import { Button } from '@/components/common';
-import { Dispatch, SetStateAction, useState } from 'react';
+import { Dispatch, RefObject, SetStateAction, useState } from 'react';
 import * as Styled from './ControlSection.styled';
 import type {
   PreviewBackgroundColor,
@@ -18,6 +18,7 @@ interface ControlSectionProps {
   setCurrentBackground: Dispatch<SetStateAction<PreviewBackgroundColor>>;
   setCurrentSnack: Dispatch<SetStateAction<PreviewSnack>>;
   setIsVisibleTalkMySelf: Dispatch<SetStateAction<boolean>>;
+  talkMySelfRef: RefObject<HTMLInputElement>;
 }
 
 const ControlSection = ({
@@ -27,6 +28,7 @@ const ControlSection = ({
   setCurrentBackground,
   setCurrentSnack,
   setIsVisibleTalkMySelf,
+  talkMySelfRef,
 }: ControlSectionProps) => {
   const [currentCategory, setCurrentCategory] = useState<ControlCategory>('background');
 
@@ -56,6 +58,7 @@ const ControlSection = ({
         setCurrentBackground={setCurrentBackground}
         setCurrentSnack={setCurrentSnack}
         setIsVisibleTalkMySelf={setIsVisibleTalkMySelf}
+        talkMySelfRef={talkMySelfRef}
       />
     </Styled.ControlSection>
   );

--- a/src/components/generate/PreviewSection/PreviewSection.component.tsx
+++ b/src/components/generate/PreviewSection/PreviewSection.component.tsx
@@ -2,7 +2,7 @@ import Snow from '@/assets/svg/snow-bg.svg';
 import Sunset from '@/assets/svgComponent/Sunset.component';
 import Morning from '@/assets/svg/morning-bg.svg';
 import Night from '@/assets/svg/night-bg.svg';
-import { ChangeEventHandler, Dispatch, SetStateAction } from 'react';
+import { ChangeEventHandler, Dispatch, forwardRef, SetStateAction } from 'react';
 import * as Styled from './PreviewSection.styled';
 
 const backgroundWindows = {
@@ -29,50 +29,49 @@ interface PreviewSectionProps {
   setTalkMySelf: Dispatch<SetStateAction<string>>;
 }
 
-const PreviewSection = ({
-  backgroundColor,
-  snack,
-  talkMySelf,
-  isVisibleTalkMySelf,
-  setTalkMySelf,
-}: PreviewSectionProps) => {
-  const SnackImage = snack ? snacks[snack] : null;
-  const BackgroundWindowImage = backgroundWindows[backgroundColor];
+const PreviewSection = forwardRef<HTMLInputElement, PreviewSectionProps>(
+  ({ backgroundColor, snack, talkMySelf, isVisibleTalkMySelf, setTalkMySelf }, ref) => {
+    const SnackImage = snack ? snacks[snack] : null;
+    const BackgroundWindowImage = backgroundWindows[backgroundColor];
 
-  const handleChangeTalkMySelf: ChangeEventHandler<HTMLInputElement> = ({ target }) => {
-    const { value } = target;
-    if (value.length > 8) return;
-    setTalkMySelf(value);
-  };
+    const handleChangeTalkMySelf: ChangeEventHandler<HTMLInputElement> = ({ target }) => {
+      const { value } = target;
+      if (value.length > 8) return;
+      setTalkMySelf(value);
+    };
 
-  return (
-    <Styled.PreviewSection>
-      <Styled.MarginBox />
-      <Styled.Paragraph>매숑이의 {'\n'}작업 환경을 만들어주세요</Styled.Paragraph>
-      <Styled.Preview>
-        <Styled.PreviewBackground backgroundColor={backgroundColor}>
-          {backgroundColor !== 'black50' && (
-            <Styled.BackgroundWindowWrapper>
-              <BackgroundWindowImage />
-            </Styled.BackgroundWindowWrapper>
+    return (
+      <Styled.PreviewSection>
+        <Styled.MarginBox />
+        <Styled.Paragraph>매숑이의 {'\n'}작업 환경을 만들어주세요</Styled.Paragraph>
+        <Styled.Preview>
+          <Styled.PreviewBackground backgroundColor={backgroundColor}>
+            {backgroundColor !== 'black50' && (
+              <Styled.BackgroundWindowWrapper>
+                <BackgroundWindowImage />
+              </Styled.BackgroundWindowWrapper>
+            )}
+          </Styled.PreviewBackground>
+          {SnackImage && <SnackImage />}
+          <Styled.Mashong />
+          <Styled.MacBook />
+          {isVisibleTalkMySelf && (
+            <Styled.Bubble>
+              <Styled.TalkMySelfInput
+                value={talkMySelf}
+                placeholder="혼잣말 입력해죠"
+                onChange={handleChangeTalkMySelf}
+                ref={ref}
+              />
+              <Styled.BubbleTail />
+            </Styled.Bubble>
           )}
-        </Styled.PreviewBackground>
-        {SnackImage && <SnackImage />}
-        <Styled.Mashong />
-        <Styled.MacBook />
-        {isVisibleTalkMySelf && (
-          <Styled.Bubble>
-            <Styled.TalkMySelfInput
-              value={talkMySelf}
-              placeholder="혼잣말 입력해죠"
-              onChange={handleChangeTalkMySelf}
-            />
-            <Styled.BubbleTail />
-          </Styled.Bubble>
-        )}
-      </Styled.Preview>
-    </Styled.PreviewSection>
-  );
-};
+        </Styled.Preview>
+      </Styled.PreviewSection>
+    );
+  },
+);
+
+PreviewSection.displayName = 'PreviewSection';
 
 export default PreviewSection;

--- a/src/components/generate/PreviewSection/PreviewSection.styled.ts
+++ b/src/components/generate/PreviewSection/PreviewSection.styled.ts
@@ -109,7 +109,6 @@ export const Bubble = styled.div`
     left: -1rem;
     width: 10.4rem;
     height: 3rem;
-    padding: 0.8rem;
     background: ${theme.color.gray700};
     border: 0;
     border-radius: 2rem;
@@ -124,16 +123,17 @@ export const BubbleTail = styled(BubbleSvg)`
 
 export const TalkMySelfInput = styled.input`
   ${({ theme }) => css`
-    width: 100%;
-    height: 100%;
+    width: 133.33%;
+    height: 133.33%;
     color: ${theme.color.white};
     font-weight: 700;
-    font-size: 1.2rem;
+    font-size: 1.6rem;
     text-align: center;
     background: transparent;
     border: 0;
     outline: 0;
-
+    transform: scale(0.75);
+    transform-origin: left top;
     &:focus {
       border: 0;
     }

--- a/src/components/generate/TalkMySelfControl/TalkMySelfControl.component.tsx
+++ b/src/components/generate/TalkMySelfControl/TalkMySelfControl.component.tsx
@@ -1,19 +1,28 @@
 import Bubble from '@/assets/svg/bubble.svg';
 import { OptionItem, OptionList } from '@/components/generate';
-import { Dispatch, SetStateAction } from 'react';
+import { Dispatch, RefObject, SetStateAction, useEffect } from 'react';
 
 interface TalkMySelfControlProps {
   isVisibleTalkMySelf: boolean;
   setIsVisibleTalkMySelf: Dispatch<SetStateAction<boolean>>;
+  talkMySelfRef: RefObject<HTMLInputElement>;
 }
 
 const TalkMySelfControl = ({
   isVisibleTalkMySelf,
   setIsVisibleTalkMySelf,
+  talkMySelfRef,
 }: TalkMySelfControlProps) => {
+  useEffect(() => {
+    if (isVisibleTalkMySelf) {
+      talkMySelfRef.current?.focus();
+    }
+  }, [isVisibleTalkMySelf, talkMySelfRef]);
+
   const handleChangeCurrentTalkMySelf = () => {
     setIsVisibleTalkMySelf((prevVisibleState) => !prevVisibleState);
   };
+
   return (
     <OptionList>
       <OptionItem onClick={handleChangeCurrentTalkMySelf} isSelected={isVisibleTalkMySelf}>


### PR DESCRIPTION
## 변경사항

- iOS에서 input의 font-size가 16px미만이면 input에 focus가 갔을때 브라우저가 auto zoom in을 하는 현상이 있어 실제 font-size를 16px로 설정해준뒤 scale함수를 활용하여 뷰에 보이는 크기는 디자인상의 input font-size인 12px이 되도록 수정해주었습니다.
- ControlSection에서 혼잣말 옵션을 선택하면 자동으로 혼잣말 Input에 focus가 가는 기능을 추가해주었습니다.
