### PR TITLE
404 -> 홈페이지 rewrites

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,5 +1,3 @@
-const BASE_URL = 'http://localhost:3000';
-
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true,
@@ -15,7 +13,7 @@ const nextConfig = {
       fallback: [
         {
           source: '/:path*',
-          destination: BASE_URL,
+          destination: process.env.BASE_URL,
         },
       ],
     };

--- a/next.config.js
+++ b/next.config.js
@@ -8,6 +8,16 @@ const nextConfig = {
       labelFormat: '[local]',
     },
   },
+  async rewrites() {
+    return {
+      fallback: [
+        {
+          source: '/:path*',
+          destination: '/',
+        },
+      ],
+    };
+  },
   webpack(config) {
     config.module.rules.push({
       test: /\.svg$/,

--- a/next.config.js
+++ b/next.config.js
@@ -1,3 +1,5 @@
+const BASE_URL = 'http://localhost:3000';
+
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true,
@@ -13,7 +15,7 @@ const nextConfig = {
       fallback: [
         {
           source: '/:path*',
-          destination: '/',
+          destination: BASE_URL,
         },
       ],
     };


### PR DESCRIPTION
## 변경사항

- 404 페이지를 구현하기 전까지 404 페이지 대신 홈페이지(process.env.BASE_URL로 정의된 경로)로 이동시키게끔 합니다.
- next.config.js의 rewrites fallback 옵션을 사용하여 파일 시스템에 존재하는 페이지 이외에 정적 에셋 및 동적 라우팅까지 확인한 이후 404 페이지로 넘어가기 직전에 홈페이지로 이동하게끔 하였습니다. [링크](https://nextjs.org/docs/api-reference/next.config.js/rewrites)
