### PR TITLE
Web Share API - 커스텀 훅 구현

### DIFF
--- a/src/hooks/useWebShare/index.ts
+++ b/src/hooks/useWebShare/index.ts
@@ -1,0 +1,23 @@
+import { useState, useEffect } from 'react';
+import { shareContent } from './shareContent';
+
+const noop: () => void = () => undefined;
+
+const useWebShare = (onSuccess = noop, onError = noop) => {
+  const [isSupported, setIsSupported] = useState(false);
+
+  useEffect(() => {
+    if (!navigator.share) {
+      setIsSupported(false);
+    } else {
+      setIsSupported(true);
+    }
+  }, [onSuccess, onError]);
+
+  return {
+    isSupported,
+    share: shareContent(onSuccess, onError),
+  };
+};
+
+export default useWebShare;

--- a/src/hooks/useWebShare/shareContent.ts
+++ b/src/hooks/useWebShare/shareContent.ts
@@ -1,0 +1,5 @@
+export const shareContent = (onSuccess: () => void, onError: () => void) => {
+  return ({ files, text, title, url }: ShareData = {}) => {
+    navigator.share({ files, text, title, url }).then(onSuccess).catch(onError);
+  };
+};


### PR DESCRIPTION
## 변경사항

- Web Share API를 사용할 수 있는 커스텀 훅을 구현합니다. navigator.share를 사용할 수 없는 환경에서는 isSupported를 false를 반환해줍니다.
