### PR TITLE
카드 저장하기 기능 수정

### DIFF
--- a/src/components/result/ResultCard/ResultCard.component.tsx
+++ b/src/components/result/ResultCard/ResultCard.component.tsx
@@ -76,8 +76,8 @@ const ResultCard = forwardRef<HTMLDivElement, ResultCardProps>(({ platformName }
   const BackgroundWindowImage = backgroundWindows[background];
 
   return (
-    <Styled.ResultCardContainer>
-      <Styled.ResultCard platform={platformName} ref={ref}>
+    <Styled.ResultCardContainer ref={ref}>
+      <Styled.ResultCard platform={platformName}>
         <Styled.ResultCardBackground>
           <Styled.PlatformIconWrapper>
             <PlatformIcon />

--- a/src/components/result/ResultCardSection/ResultCardSection.component.tsx
+++ b/src/components/result/ResultCardSection/ResultCardSection.component.tsx
@@ -3,7 +3,6 @@ import { ResultCard } from '@/components/result';
 import { Platform, PLATFORM_NAME_MAP } from '@/constants/platform';
 import { useRef, useState } from 'react';
 import useDownloadElementToImage from '@/hooks/useDownloadElementToImage';
-import { detectInAppBrowser } from '@/utils/userAgent';
 import useCopyToClipboard from '@/hooks/useCopyClipboard';
 import useWebShare from '@/hooks/useWebShare';
 import * as Styled from './ResultCardSection.styled';
@@ -30,11 +29,6 @@ const ResultCardSection = ({ platformName }: ResultCardSectionProps) => {
   });
 
   const handleSaveImage = () => {
-    if (detectInAppBrowser('KAKAO')) {
-      setIsOpenCopyLinkModal(true);
-      return;
-    }
-
     saveImage();
   };
 

--- a/src/hooks/useDownloadElementToImage.ts
+++ b/src/hooks/useDownloadElementToImage.ts
@@ -1,23 +1,46 @@
+import { color } from '@/styles/theme/color';
 import { toPng } from 'html-to-image';
 import { RefObject, useCallback } from 'react';
+import useWebShare from './useWebShare';
 
 const useDownloadElementToImage = <T extends HTMLElement>(ref: RefObject<T>, filename: string) => {
+  const { isSupported, share } = useWebShare();
+
   const saveImage = useCallback(() => {
     if (ref.current === null) {
       return;
     }
 
-    toPng(ref.current, { cacheBust: true })
-      .then((dataUrl) => {
-        const link = document.createElement('a');
-        link.download = filename;
-        link.href = dataUrl;
-        link.click();
+    toPng(ref.current, {
+      cacheBust: true,
+      width: 480,
+      height: 720,
+      style: {
+        display: 'flex',
+        justifyContent: 'center',
+        alignItems: 'center',
+        background: color.black,
+      },
+    })
+      .then(async (dataUrl) => {
+        if (isSupported) {
+          const response = await fetch(dataUrl);
+          const blob = await response.blob();
+          const file = new File([blob], filename, { type: blob.type });
+
+          share({ files: [file] });
+        } else {
+          const link = document.createElement('a');
+          link.download = filename;
+          link.href = dataUrl;
+
+          link.click();
+        }
       })
       .catch((err) => {
         console.log(err);
       });
-  }, [ref, filename]);
+  }, [ref, isSupported, filename, share]);
 
   return { saveImage };
 };

--- a/src/hooks/useDownloadElementToImage.ts
+++ b/src/hooks/useDownloadElementToImage.ts
@@ -1,7 +1,7 @@
 import { color } from '@/styles/theme/color';
 import { toPng } from 'html-to-image';
 import { RefObject, useCallback } from 'react';
-import useWebShare from './useWebShare';
+import useWebShare from '@/hooks/useWebShare';
 
 const useDownloadElementToImage = <T extends HTMLElement>(ref: RefObject<T>, filename: string) => {
   const { isSupported, share } = useWebShare();


### PR DESCRIPTION
## 변경사항

- 기존 카드 저장하기 기능이 모든 환경에서 anchor태그의 download 어트리뷰트를 활용하는 방식이었지만 `window.navigator.share` API가 호환되는 환경에서는 해당 API의 동작을 활용하여 저장할 수 있도록 기능을 수정해주었습니다.
