### PR TITLE
iOS환경 WebShare NowAllowed 에러 대응

### DIFF
--- a/src/hooks/useWebShare/shareContent.ts
+++ b/src/hooks/useWebShare/shareContent.ts
@@ -1,5 +1,13 @@
-export const shareContent = (onSuccess: () => void, onError: () => void) => {
+export const shareContent = (onSuccess: () => void, onError: (error?: unknown) => void) => {
   return ({ files, text, title, url }: ShareData = {}) => {
-    navigator.share({ files, text, title, url }).then(onSuccess).catch(onError);
+    navigator
+      .share({ files, text, title, url })
+      .then(onSuccess)
+      .catch((error) => {
+        if (error.name === 'NotAllowedError') {
+          window.location.reload();
+        }
+        onError();
+      });
   };
 };

--- a/src/hooks/useWebShare/shareContent.ts
+++ b/src/hooks/useWebShare/shareContent.ts
@@ -4,10 +4,10 @@ export const shareContent = (onSuccess: () => void, onError: (error?: unknown) =
       .share({ files, text, title, url })
       .then(onSuccess)
       .catch((error) => {
+        onError();
         if (error.name === 'NotAllowedError') {
           window.location.reload();
         }
-        onError();
       });
   };
 };


### PR DESCRIPTION
## 변경사항

- ios환경에서 WebShare 저장하기 기능을 사용했을시 Promise가 fulfilled되지 않는 현상이 있어 다시 WebShare기능을 사용하려고 하면 기능이 동작하지 않고 NowAllowedError가 트리거되는 현상이 있어 해당 Error가 트리거되면 window.location.reload 함수를 이용하여 강제로 reload가 되어 다시 기능이 동작하게끔 구현해주었습니다.
