### PR TITLE
스타일 수정을 통한 서비스 UX개선

### DIFF
--- a/pages/generate/[platformName].tsx
+++ b/pages/generate/[platformName].tsx
@@ -1,5 +1,10 @@
 import { NavigationBar } from '@/components/common';
-import { ControlSection, GenerateLayout, PreviewSection } from '@/components/generate';
+import {
+  ControlSection,
+  DescriptionSection,
+  GenerateLayout,
+  PreviewSection,
+} from '@/components/generate';
 import type {
   PreviewBackgroundColor,
   PreviewSnack,
@@ -53,6 +58,7 @@ const GeneratePage: NextPage<GeneratePageProps> = ({ platformName }) => {
         rightButtonEvent={handleGoToResultPage}
       />
       <GenerateLayout>
+        <DescriptionSection />
         <PreviewSection
           backgroundColor={currentBackground}
           snack={currentSnack}

--- a/src/components/common/Layout/Layout.styled.ts
+++ b/src/components/common/Layout/Layout.styled.ts
@@ -16,3 +16,27 @@ export const Layout = styled.div<{ vh: number }>`
     `;
   }}
 `;
+
+export const BackgroundTop = styled.div`
+  ${({ theme }) => css`
+    position: fixed;
+    top: -100px;
+    z-index: ${theme.zIndex.background};
+    width: 100%;
+    max-width: 76.8rem;
+    height: 50%;
+    background: ${theme.color.gray900};
+  `}
+`;
+
+export const BackgroundBottom = styled.div`
+  ${({ theme }) => css`
+    position: fixed;
+    bottom: 0;
+    z-index: ${theme.zIndex.background};
+    width: 100%;
+    max-width: 76.8rem;
+    height: 50%;
+    background: ${theme.color.gray900}; ;
+  `}
+`;

--- a/src/components/generate/ControlSection/ControlSection.styled.ts
+++ b/src/components/generate/ControlSection/ControlSection.styled.ts
@@ -1,4 +1,3 @@
-import { css } from '@emotion/react';
 import styled from '@emotion/styled';
 
 export const ControlSection = styled.section`
@@ -10,20 +9,4 @@ export const Categories = styled.div`
   flex-flow: row nowrap;
   gap: 1.2rem;
   justify-content: center;
-`;
-
-export const OptionList = styled.ul`
-  display: flex;
-  gap: 1.4rem;
-  justify-content: center;
-  margin-top: 2.4rem;
-`;
-
-export const OptionItem = styled.li`
-  ${({ theme }) => css`
-    padding: 1.2rem;
-    border: 0.22rem solid ${theme.color.gray700};
-    border-radius: 1.3rem;
-    cursor: pointer;
-  `}
 `;

--- a/src/components/generate/ControlSection/ControlSection.styled.ts
+++ b/src/components/generate/ControlSection/ControlSection.styled.ts
@@ -1,7 +1,7 @@
 import styled from '@emotion/styled';
 
 export const ControlSection = styled.section`
-  margin-top: 4.5vh;
+  margin-top: 3rem;
 `;
 
 export const Categories = styled.div`

--- a/src/components/generate/DescriptionSection/DescriptionSection.component.tsx
+++ b/src/components/generate/DescriptionSection/DescriptionSection.component.tsx
@@ -1,0 +1,11 @@
+import * as Styled from './DescriptionSection.styled';
+
+const DescriptionSection = () => {
+  return (
+    <Styled.DescriptionSection>
+      <Styled.Paragraph>매숑이의 {'\n'}작업 환경을 만들어주세요</Styled.Paragraph>
+    </Styled.DescriptionSection>
+  );
+};
+
+export default DescriptionSection;

--- a/src/components/generate/DescriptionSection/DescriptionSection.styled.ts
+++ b/src/components/generate/DescriptionSection/DescriptionSection.styled.ts
@@ -1,0 +1,17 @@
+import { css } from '@emotion/react';
+import styled from '@emotion/styled';
+
+export const DescriptionSection = styled.section`
+  margin: 3rem 0;
+`;
+
+export const Paragraph = styled.p`
+  ${({ theme }) => css`
+    color: ${theme.color.white};
+    font-weight: 700;
+    font-size: 2.4rem;
+    line-height: 1.2;
+    white-space: pre-wrap;
+    text-align: center;
+  `}
+`;

--- a/src/components/generate/GenerateLayout/GenerateLayout.component.tsx
+++ b/src/components/generate/GenerateLayout/GenerateLayout.component.tsx
@@ -6,7 +6,13 @@ interface GenerateLayoutProps {
 }
 
 const GenerateLayout = ({ children }: GenerateLayoutProps) => {
-  return <Styled.GenerateLayout>{children}</Styled.GenerateLayout>;
+  return (
+    <Styled.GenerateLayout>
+      <Styled.BackgroundTop />
+      {children}
+      <Styled.BackgroundBottom />
+    </Styled.GenerateLayout>
+  );
 };
 
 export default GenerateLayout;

--- a/src/components/generate/GenerateLayout/GenerateLayout.styled.ts
+++ b/src/components/generate/GenerateLayout/GenerateLayout.styled.ts
@@ -1,3 +1,4 @@
+import { css } from '@emotion/react';
 import styled from '@emotion/styled';
 
 export const GenerateLayout = styled.div`
@@ -8,4 +9,28 @@ export const GenerateLayout = styled.div`
   height: 100%;
   max-height: 76rem;
   padding: 0rem 0 6rem;
+`;
+
+export const BackgroundTop = styled.div`
+  ${({ theme }) => css`
+    position: fixed;
+    top: 0;
+    z-index: ${theme.zIndex.background};
+    width: 100%;
+    max-width: 76.8rem;
+    height: 50%;
+    background: ${theme.color.gray900};
+  `}
+`;
+
+export const BackgroundBottom = styled.div`
+  ${({ theme }) => css`
+    position: fixed;
+    bottom: 0;
+    z-index: ${theme.zIndex.background};
+    width: 100%;
+    max-width: 76.8rem;
+    height: 50%;
+    background: ${theme.color.gray900};
+  `}
 `;

--- a/src/components/generate/OptionItem/OptionItem.styled.ts
+++ b/src/components/generate/OptionItem/OptionItem.styled.ts
@@ -9,6 +9,7 @@ export const OptionItem = styled.li<{ isSelected: boolean }>`
     border: 0.2rem solid ${isSelected ? 'transparent' : theme.color.gray700};
     border-radius: 1.3rem;
     cursor: pointer;
+    -webkit-tap-highlight-color: rgba(255, 255, 255, 0);
   `}
 `;
 

--- a/src/components/generate/PreviewSection/PreviewSection.component.tsx
+++ b/src/components/generate/PreviewSection/PreviewSection.component.tsx
@@ -39,8 +39,6 @@ const PreviewSection = forwardRef<HTMLInputElement, PreviewSectionProps>(
 
     return (
       <Styled.PreviewSection>
-        <Styled.MarginBox />
-        <Styled.Paragraph>매숑이의 {'\n'}작업 환경을 만들어주세요</Styled.Paragraph>
         <Styled.Preview>
           <Styled.PreviewBackground backgroundColor={backgroundColor}>
             {BackgroundWindowImage && <BackgroundWindowImage />}

--- a/src/components/generate/PreviewSection/PreviewSection.styled.ts
+++ b/src/components/generate/PreviewSection/PreviewSection.styled.ts
@@ -19,28 +19,11 @@ export const PreviewSection = styled.section`
   justify-content: space-between;
 `;
 
-export const Paragraph = styled.p`
-  ${({ theme }) => css`
-    color: ${theme.color.white};
-    font-weight: 700;
-    font-size: 2.4rem;
-    line-height: 1.2;
-    white-space: pre-wrap;
-    text-align: center;
-  `}
-`;
-
-export const MarginBox = styled.div`
-  height: 4.5vh;
-  min-height: 3rem;
-  max-height: 6rem;
-`;
-
 export const Preview = styled.div`
   position: relative;
   width: 22.6rem;
   height: 24rem;
-  margin: 8.867vh auto 0;
+  margin: 0 auto;
 `;
 
 export const Mashong = styled(MashongSvg)`

--- a/src/components/generate/index.ts
+++ b/src/components/generate/index.ts
@@ -7,3 +7,4 @@ export { default as BackgroundOptions } from './BackgroundOptions/BackgroundOpti
 export { default as SnackOptions } from './SnackOptions/SnackOptions.component';
 export { default as TalkMySelfControl } from './TalkMySelfControl/TalkMySelfControl.component';
 export { default as CategoryOption } from './CategoryOption/CategoryOption.component';
+export { default as DescriptionSection } from './DescriptionSection/DescriptionSection.component';

--- a/src/components/home/HomeLayout/HomeLayout.component.tsx
+++ b/src/components/home/HomeLayout/HomeLayout.component.tsx
@@ -2,7 +2,12 @@ import type { PropsWithChildren } from 'react';
 import * as Styled from './HomeLayout.styled';
 
 const HomeLayout = ({ children }: PropsWithChildren) => {
-  return <Styled.Main>{children}</Styled.Main>;
+  return (
+    <Styled.Main>
+      <Styled.BackgroundTop />
+      {children}
+    </Styled.Main>
+  );
 };
 
 export default HomeLayout;

--- a/src/components/home/HomeLayout/HomeLayout.styled.ts
+++ b/src/components/home/HomeLayout/HomeLayout.styled.ts
@@ -1,3 +1,4 @@
+import { css } from '@emotion/react';
 import styled from '@emotion/styled';
 
 export const Main = styled.main`
@@ -7,4 +8,16 @@ export const Main = styled.main`
   width: 100%;
   height: 100%;
   overflow: hidden;
+`;
+
+export const BackgroundTop = styled.div`
+  ${({ theme }) => css`
+    position: fixed;
+    top: 0;
+    z-index: ${theme.zIndex.background};
+    width: 100%;
+    max-width: 76.8rem;
+    height: 50%;
+    background: ${theme.color.gray900};
+  `}
 `;

--- a/src/components/registration/RegistrationLayout/RegistrationLayout.component.tsx
+++ b/src/components/registration/RegistrationLayout/RegistrationLayout.component.tsx
@@ -2,7 +2,13 @@ import type { PropsWithChildren } from 'react';
 import * as Styled from './RegistrationLayout.styled';
 
 const RegistrationLayout = ({ children }: PropsWithChildren) => {
-  return <Styled.Main>{children}</Styled.Main>;
+  return (
+    <Styled.Main>
+      <Styled.BackgroundTop />
+      {children}
+      <Styled.BackgroundBottom />
+    </Styled.Main>
+  );
 };
 
 export default RegistrationLayout;

--- a/src/components/registration/RegistrationLayout/RegistrationLayout.styled.ts
+++ b/src/components/registration/RegistrationLayout/RegistrationLayout.styled.ts
@@ -1,6 +1,31 @@
+import { css } from '@emotion/react';
 import styled from '@emotion/styled';
 
 export const Main = styled.main`
   display: flex;
   justify-content: center;
+`;
+
+export const BackgroundTop = styled.div`
+  ${({ theme }) => css`
+    position: fixed;
+    top: 0;
+    z-index: ${theme.zIndex.background};
+    width: 100%;
+    max-width: 76.8rem;
+    height: 50%;
+    background: ${theme.color.gray900};
+  `}
+`;
+
+export const BackgroundBottom = styled.div`
+  ${({ theme }) => css`
+    position: fixed;
+    bottom: 0;
+    z-index: ${theme.zIndex.background};
+    width: 100%;
+    max-width: 76.8rem;
+    height: 50%;
+    background: ${theme.color.gray900};
+  `}
 `;

--- a/src/components/result/ResultCardSection/ResultCardSection.component.tsx
+++ b/src/components/result/ResultCardSection/ResultCardSection.component.tsx
@@ -57,7 +57,7 @@ const ResultCardSection = ({ platformName }: ResultCardSectionProps) => {
       {isOpenCopyLinkModal && (
         <ConfirmModalDialog
           heading="링크 복사하기"
-          paragraph={`${BASE_URL}이${'\n'} 클립보드에 복사됩니다`}
+          paragraph={`${BASE_URL}이${'\n'}클립보드에 복사됩니다`}
           approvalButtonMessage="링크 복사"
           cancelButtonMessage="취소"
           handleApprovalButton={copy}

--- a/src/components/result/ResultLayout/ResultLayout.component.tsx
+++ b/src/components/result/ResultLayout/ResultLayout.component.tsx
@@ -2,7 +2,12 @@ import { PropsWithChildren } from 'react';
 import * as Styled from './ResultLayout.styled';
 
 const ResultLayout = ({ children }: PropsWithChildren) => {
-  return <Styled.ResultLayout>{children}</Styled.ResultLayout>;
+  return (
+    <Styled.ResultLayout>
+      <Styled.BackgroundTop />
+      {children}
+    </Styled.ResultLayout>
+  );
 };
 
 export default ResultLayout;

--- a/src/components/result/ResultLayout/ResultLayout.styled.ts
+++ b/src/components/result/ResultLayout/ResultLayout.styled.ts
@@ -3,6 +3,7 @@ import styled from '@emotion/styled';
 
 export const ResultLayout = styled.div`
   ${({ theme }) => css`
+    position: relative;
     z-index: ${theme.zIndex.content};
     display: flex;
     flex-flow: column nowrap;
@@ -10,5 +11,17 @@ export const ResultLayout = styled.div`
     align-items: center;
     overflow-x: hidden;
     overflow-y: scroll;
+  `}
+`;
+
+export const BackgroundTop = styled.div`
+  ${({ theme }) => css`
+    position: fixed;
+    top: 0;
+    z-index: ${theme.zIndex.background};
+    width: 100%;
+    max-width: 76.8rem;
+    height: 50%;
+    background: ${theme.color.gray900};
   `}
 `;

--- a/src/constants/seo.ts
+++ b/src/constants/seo.ts
@@ -15,7 +15,8 @@ export const defaultSEO: DefaultSeoProps = {
   additionalMetaTags: [
     {
       name: 'viewport',
-      content: 'width=device-width, initial-scale=1.0',
+      content:
+        'width=device-width, initial-scale=1, maximum-scale=1, minimum-scale=1, user-scalable=0',
     },
     {
       name: 'keywords',

--- a/src/hooks/useDetectViewportHeight.ts
+++ b/src/hooks/useDetectViewportHeight.ts
@@ -1,14 +1,24 @@
+import { detectOS } from '@/utils/userAgent';
+import { throttle } from 'lodash-es';
 import { useEffect, useState } from 'react';
 
 const useDetectViewportHeight = () => {
   const [vh, setVh] = useState(0);
 
   useEffect(() => {
-    const detectViewportHeight = () => {
+    const detectViewportHeight = throttle(() => {
       setVh(window.innerHeight * 0.01);
-    };
+    }, 200);
+
+    if (!detectOS('Android') && !detectOS('iOS')) {
+      window.addEventListener('resize', detectViewportHeight);
+    }
 
     detectViewportHeight();
+
+    return () => {
+      window.removeEventListener('resize', detectViewportHeight);
+    };
   }, []);
 
   return { vh };

--- a/src/hooks/useDetectViewportHeight.ts
+++ b/src/hooks/useDetectViewportHeight.ts
@@ -1,21 +1,14 @@
 import { useEffect, useState } from 'react';
-import throttle from 'lodash-es/throttle';
 
 const useDetectViewportHeight = () => {
   const [vh, setVh] = useState(0);
 
   useEffect(() => {
-    const detectViewportHeight = throttle(() => {
+    const detectViewportHeight = () => {
       setVh(window.innerHeight * 0.01);
-    }, 200);
-
-    window.addEventListener('resize', detectViewportHeight);
+    };
 
     detectViewportHeight();
-
-    return () => {
-      window.removeEventListener('resize', detectViewportHeight);
-    };
   }, []);
 
   return { vh };

--- a/src/styles/reset.ts
+++ b/src/styles/reset.ts
@@ -147,6 +147,7 @@ export const resetCss = css`
   body *::before,
   body *::after {
     box-sizing: border-box;
+    user-select: none;
   }
 
   a {

--- a/src/styles/reset.ts
+++ b/src/styles/reset.ts
@@ -152,6 +152,7 @@ export const resetCss = css`
   a {
     color: #ffffff;
     text-decoration: none;
+    -webkit-tap-highlight-color: rgba(255, 255, 255, 0);
   }
 
   img {
@@ -163,6 +164,7 @@ export const resetCss = css`
     border-color: transparent;
     cursor: pointer;
     user-select: none;
+    -webkit-tap-highlight-color: rgba(255, 255, 255, 0);
 
     &:disabled {
       cursor: not-allowed;


### PR DESCRIPTION
## 변경사항

- 모바일 환경에서 대화형 요소 포커스시 나오는 음영 효과를 제거해주었습니다.
![image](https://user-images.githubusercontent.com/71176945/212875979-93e9755e-ac78-4d78-93b7-74651bc33039.png)

- 결과 페이지에서 공유하기 버튼을 눌렀을때 share가 지원되지 않으면 노출되는 링크 복사하기 다이얼로그 내부 텍스트 두번째 줄의 시작부분에 있는 공백 문자열을 제거해주었습니다.
- 모바일 환경에서 resize시 vh를 다시 계산하는 동작이 앱이 끊기는것 같은 경험을 준다고 판단하여 제거해주었습니다. detectOS를 사용하여 Android와 iOS 환경에서만 동작하지 않게 해주었고 나머지 환경에서는 여전히 resize 이벤트가 일어나면 vh를 다시 계산합니다.
- 앱 전역에 `user-select: none` 속성을 적용해 드래그 동작을 하지 못하도록 막아주었습니다.
- meta태그를 활용해 viewport의 zoom in, zoom out을 막아주었습니다. 다만, iOS 환경에서 PintZoom 동작만은 막지 못하도록 되어 있어 예외적으로 iOS에서만 zoom in, zoom out이 가능한 상태입니다.
- 위, 아래로 over scroll시 Layout 바깥 영역인 body영역의 background가 보이게 되어 각 Layout마다 body영역 위에 깔리는 Layout과 background 색상이 같은 영역을 추가해주었습니다.
- generate페이지에서 디자인상 스크롤이 생기면 안되는 vh에서 스크롤이 생기는 이슈가 있어 generate페이지 내에 렌더링되는 DOM 구조를 변경하고 이에 따라 flex 속성을 활용해 디자인과 동일한 동작이 되도록 수정해주었습니다.