### PR TITLE
generate시 이미 선택된 slot을 다시 선택하면 취소되는 기능 추가

### DIFF
--- a/src/components/generate/BackgroundOptions/BackgroundOptions.component.tsx
+++ b/src/components/generate/BackgroundOptions/BackgroundOptions.component.tsx
@@ -32,6 +32,11 @@ interface BackgroundOptionsProps {
 
 const BackgroundOptions = ({ currentBackground, setCurrentBackground }: BackgroundOptionsProps) => {
   const handleChangeCurrentBackground = (background: PreviewBackgroundColor) => {
+    if (background === currentBackground) {
+      setCurrentBackground('black50');
+      return;
+    }
+
     setCurrentBackground(background);
   };
   return (

--- a/src/components/generate/SnackOptions/SnackOptions.component.tsx
+++ b/src/components/generate/SnackOptions/SnackOptions.component.tsx
@@ -32,6 +32,11 @@ interface SnackOptionsProps {
 
 const SnackOptions = ({ currentSnack, setCurrentSnack }: SnackOptionsProps) => {
   const handleChangeCurrentBackground = (snack: PreviewSnack) => {
+    if (snack === currentSnack) {
+      setCurrentSnack(null);
+      return;
+    }
+
     setCurrentSnack(snack);
   };
   return (


### PR DESCRIPTION
## 변경사항

- generate페이지에서 배경, 간식에 대한 slot이 이미 선택된것이라면 다시 선택했을때 선택이 취소되도록 기능을 추가해주었습니다.
