### PR TITLE
카드 생성시 보여지는 인터렉션 구현

### DIFF
--- a/@types/custom-types/emotion.d.ts
+++ b/@types/custom-types/emotion.d.ts
@@ -1,10 +1,12 @@
 import '@emotion/react';
 import { ColorType } from '@/styles/theme/color';
 import { ZIndexType } from '@/styles/theme/zIndex';
+import { AnimationType } from '@/styles/theme/animation';
 
 declare module '@emotion/react' {
   export interface Theme {
     color: ColorType;
     zIndex: ZIndexType;
+    animation: AnimationType;
   }
 }

--- a/pages/generate/[platformName].tsx
+++ b/pages/generate/[platformName].tsx
@@ -4,6 +4,7 @@ import {
   DescriptionSection,
   GenerateLayout,
   PreviewSection,
+  InteractionSection,
 } from '@/components/generate';
 import type {
   PreviewBackgroundColor,
@@ -29,6 +30,7 @@ const GeneratePage: NextPage<GeneratePageProps> = ({ platformName }) => {
   const [currentSnack, setCurrentSnack] = useState<PreviewSnack>(null);
   const [talkMySelf, setTalkMySelf] = useState('');
   const [isVisibleTalkMySelf, setIsVisibleTalkMySelf] = useState(false);
+  const [isGenerating, setIsGenerating] = useState(false);
 
   const talkMySelfRef = useRef<HTMLInputElement>(null);
 
@@ -43,14 +45,19 @@ const GeneratePage: NextPage<GeneratePageProps> = ({ platformName }) => {
   const name = router.query.name as string;
   const selectedOptionParams = new URLSearchParams({ ...selectedOptions, name }).toString();
   const handleGoToResultPage = () => {
-    router.push(`${RESULT_ROUTES[platformName]}?${selectedOptionParams}`);
+    setIsGenerating(true);
+    setTimeout(() => {
+      router.push(`${RESULT_ROUTES[platformName]}?${selectedOptionParams}`);
+    }, 2000);
   };
 
   const handleBackToPrevPage = () => {
     router.back();
   };
 
-  return (
+  return isGenerating ? (
+    <InteractionSection />
+  ) : (
     <>
       <NavigationBar
         rightButtonText="다음"

--- a/src/components/common/BaseCard/BaseCard.component.tsx
+++ b/src/components/common/BaseCard/BaseCard.component.tsx
@@ -1,7 +1,7 @@
 import * as Styled from './BaseCard.styled';
 
 interface BaseCardProps {
-  className: string;
+  className?: string;
 }
 
 const BaseCard = ({ className }: BaseCardProps) => {

--- a/src/components/generate/InteractionSection/InteractionSection.component.tsx
+++ b/src/components/generate/InteractionSection/InteractionSection.component.tsx
@@ -1,0 +1,25 @@
+import { LinearGradientSphere } from '@/components/common';
+import * as Styled from './InteractionSection.styled';
+
+const InteractionSection = () => {
+  return (
+    <Styled.InteractionSection>
+      <Styled.ContentsContainer>
+        <Styled.Title>두근두근!{'\n'}과연 내 카드의 모습은!?</Styled.Title>
+        <Styled.Scene>
+          <Styled.ZoomInOutContainer>
+            <Styled.InteractiveBaseCard />
+          </Styled.ZoomInOutContainer>
+        </Styled.Scene>
+      </Styled.ContentsContainer>
+      <Styled.SphereContainer>
+        <LinearGradientSphere />
+      </Styled.SphereContainer>
+      <Styled.BlackBackground>
+        <Styled.AnimationEndMessage>앗{'\n'}내 카드의 상태가..!?</Styled.AnimationEndMessage>
+      </Styled.BlackBackground>
+    </Styled.InteractionSection>
+  );
+};
+
+export default InteractionSection;

--- a/src/components/generate/InteractionSection/InteractionSection.styled.ts
+++ b/src/components/generate/InteractionSection/InteractionSection.styled.ts
@@ -1,0 +1,124 @@
+import { BaseCard } from '@/components/common';
+import { css, keyframes } from '@emotion/react';
+import styled from '@emotion/styled';
+
+export const InteractionSection = styled.section`
+  ${({ theme }) => css`
+    position: fixed;
+    top: 0;
+    left: 50%;
+    width: 100%;
+    max-width: 76.8rem;
+    height: 100%;
+    background: ${theme.color.gray900};
+    transform: translate3d(-50%, 0, 0);
+
+    &::after {
+      position: fixed;
+      bottom: 0;
+      display: block;
+      width: 100%;
+      height: 28.6rem;
+      background: linear-gradient(180deg, rgba(0, 0, 0, 0) 0%, #000000 100%);
+      content: '';
+    }
+  `}
+`;
+
+export const Title = styled.p`
+  ${({ theme }) => css`
+    display: block;
+    margin-bottom: 5rem;
+    color: ${theme.color.white};
+    font-weight: 700;
+    font-size: 2.4rem;
+    line-height: 2.9rem;
+    white-space: pre-line;
+    text-align: center;
+  `}
+`;
+
+export const ContentsContainer = styled.div`
+  ${({ theme }) => css`
+    position: relative;
+    z-index: ${theme.zIndex.content};
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    width: 100%;
+    height: 100%;
+  `}
+`;
+
+export const SphereContainer = styled.div`
+  position: absolute;
+  bottom: -30rem;
+  left: 50%;
+  width: 60rem;
+  height: 60rem;
+  transform: translateX(-50%);
+`;
+
+export const Scene = styled.div`
+  perspective: 50rem;
+`;
+
+const zoomInOut = keyframes`
+  0% {
+    transform: scale(0.5);
+  }
+  50% {
+    transform: scale(1);
+  }
+  100% {
+    transform: scale(0);
+  }
+`;
+
+export const ZoomInOutContainer = styled.div`
+  animation: ${zoomInOut} 2s ease-in-out forwards;
+`;
+
+const rotateCard = keyframes`
+  from {
+    transform: rotateY(0deg);
+  }
+  to {
+    transform: rotateY(360deg);
+  }
+`;
+
+export const InteractiveBaseCard = styled(BaseCard)`
+  animation: ${rotateCard} 2s ease-in-out;
+`;
+
+export const BlackBackground = styled.div`
+  ${({ theme }) => css`
+    ${theme.animation.fadeIn({ duration: 1.5, delay: 1 })};
+    position: absolute;
+    top: 0;
+    left: 0;
+    z-index: ${theme.zIndex.content};
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 100%;
+    height: 100%;
+    background: ${theme.color.black};
+    opacity: 0;
+  `}
+`;
+
+export const AnimationEndMessage = styled.p`
+  ${({ theme }) => css`
+    ${theme.animation.fadeIn({ duration: 1, delay: 1.5 })};
+    color: ${theme.color.white};
+    font-weight: 700;
+    font-size: 2rem;
+    line-height: 1.2;
+    white-space: pre-line;
+    text-align: center;
+    opacity: 0;
+  `}
+`;

--- a/src/components/generate/index.ts
+++ b/src/components/generate/index.ts
@@ -8,3 +8,4 @@ export { default as SnackOptions } from './SnackOptions/SnackOptions.component';
 export { default as TalkMySelfControl } from './TalkMySelfControl/TalkMySelfControl.component';
 export { default as CategoryOption } from './CategoryOption/CategoryOption.component';
 export { default as DescriptionSection } from './DescriptionSection/DescriptionSection.component';
+export { default as InteractionSection } from './InteractionSection/InteractionSection.component';

--- a/src/components/result/EventSection/EventSection.styled.ts
+++ b/src/components/result/EventSection/EventSection.styled.ts
@@ -3,10 +3,14 @@ import styled from '@emotion/styled';
 import SparkleSvg from '@/assets/svg/sparkle.svg';
 
 export const EventSection = styled.section`
-  width: 31.5rem;
-  padding: 2.4rem 2rem;
-  background: linear-gradient(98.54deg, rgba(255, 28, 96, 0.2) 0%, rgba(82, 67, 255, 0.2) 100%);
-  border-radius: 1.2rem;
+  ${({ theme }) => css`
+    ${theme.animation.fadeUp({ duration: 0.8, delay: 0.3, move: 4 })};
+    width: 31.5rem;
+    padding: 2.4rem 2rem;
+    background: linear-gradient(98.54deg, rgba(255, 28, 96, 0.2) 0%, rgba(82, 67, 255, 0.2) 100%);
+    border-radius: 1.2rem;
+    opacity: 0;
+  `}
 `;
 
 export const Heading = styled.h3`

--- a/src/components/result/RecruitSection/RecruitSection.styled.ts
+++ b/src/components/result/RecruitSection/RecruitSection.styled.ts
@@ -3,7 +3,11 @@ import styled from '@emotion/styled';
 import Image from 'next/image';
 
 export const RecruitAnchor = styled.a`
-  margin: 3.2rem 0 4rem;
+  ${({ theme }) => css`
+    ${theme.animation.fadeUp({ duration: 0.8, delay: 0.3, move: 4 })};
+    margin: 3.2rem 0 4rem;
+    opacity: 0;
+  `}
 `;
 
 export const RecruitSection = styled.section`

--- a/src/components/result/ResultCard/ResultCard.component.tsx
+++ b/src/components/result/ResultCard/ResultCard.component.tsx
@@ -55,65 +55,68 @@ export type Snack = 'coffee' | 'beer' | 'wine' | 'energy' | null;
 
 interface ResultCardProps {
   platformName: Platform;
+  className?: string;
 }
 
-const ResultCard = forwardRef<HTMLDivElement, ResultCardProps>(({ platformName }, ref) => {
-  const router = useRouter();
+const ResultCard = forwardRef<HTMLDivElement, ResultCardProps>(
+  ({ platformName, className }, ref) => {
+    const router = useRouter();
 
-  const { query } = router;
+    const { query } = router;
 
-  const [background, snack, talkMySelf, isVisibleTalkMySelf, name] = [
-    query.background as Background,
-    query.snack as Snack,
-    query.talkMySelf as string,
-    query.isVisibleTalkMySelf === 'true',
-    query.name as string,
-  ];
+    const [background, snack, talkMySelf, isVisibleTalkMySelf, name] = [
+      query.background as Background,
+      query.snack as Snack,
+      query.talkMySelf as string,
+      query.isVisibleTalkMySelf === 'true',
+      query.name as string,
+    ];
 
-  const PlatformIcon = platformIcons[platformName];
-  const PlatformBubble = platformBubbles[platformName];
-  const SnackImage = snack ? snacks[snack] : null;
-  const BackgroundWindowImage = backgroundWindows[background];
+    const PlatformIcon = platformIcons[platformName];
+    const PlatformBubble = platformBubbles[platformName];
+    const SnackImage = snack ? snacks[snack] : null;
+    const BackgroundWindowImage = backgroundWindows[background];
 
-  return (
-    <Styled.ResultCardContainer ref={ref}>
-      <Styled.ResultCard platform={platformName}>
-        <Styled.ResultCardBackground>
-          <Styled.PlatformIconWrapper>
-            <PlatformIcon />
-          </Styled.PlatformIconWrapper>
-          <Styled.MashongWrapper>
-            <Styled.PlatformBorder platform={platformName}>
-              <Styled.PlatformBorderBg />
-            </Styled.PlatformBorder>
-            <Styled.MashongBackground background={background} />
-            {BackgroundWindowImage && <BackgroundWindowImage />}
-            <Styled.Mashong />
-            <Styled.MacBook />
-            {SnackImage && <SnackImage />}
-            {isVisibleTalkMySelf && (
-              <Styled.BubbleWrapper>
-                <PlatformBubble />
-                <Styled.TalkMySelf>{talkMySelf.slice(0, 8)}</Styled.TalkMySelf>
-              </Styled.BubbleWrapper>
-            )}
-          </Styled.MashongWrapper>
-          <Styled.PlatformName platform={platformName}>
-            {PLATFORM_NAME_MAP[platformName]}
-          </Styled.PlatformName>
-          <Styled.Name>{name?.slice(0, 6)}</Styled.Name>
-        </Styled.ResultCardBackground>
-        <Styled.SparkleLeftTop />
-        <Styled.SparkleRightTop />
-        <Styled.SparkleLeftBottom />
-        <Styled.SparkleRightBottom />
-      </Styled.ResultCard>
-      <Styled.LinearGradientSphereWrapper>
-        <LinearGradientSphere platform={platformName} />
-      </Styled.LinearGradientSphereWrapper>
-    </Styled.ResultCardContainer>
-  );
-});
+    return (
+      <Styled.ResultCardContainer ref={ref}>
+        <Styled.ResultCard platform={platformName} className={className}>
+          <Styled.ResultCardBackground>
+            <Styled.PlatformIconWrapper>
+              <PlatformIcon />
+            </Styled.PlatformIconWrapper>
+            <Styled.MashongWrapper>
+              <Styled.PlatformBorder platform={platformName}>
+                <Styled.PlatformBorderBg />
+              </Styled.PlatformBorder>
+              <Styled.MashongBackground background={background} />
+              {BackgroundWindowImage && <BackgroundWindowImage />}
+              <Styled.Mashong />
+              <Styled.MacBook />
+              {SnackImage && <SnackImage />}
+              {isVisibleTalkMySelf && (
+                <Styled.BubbleWrapper>
+                  <PlatformBubble />
+                  <Styled.TalkMySelf>{talkMySelf.slice(0, 8)}</Styled.TalkMySelf>
+                </Styled.BubbleWrapper>
+              )}
+            </Styled.MashongWrapper>
+            <Styled.PlatformName platform={platformName}>
+              {PLATFORM_NAME_MAP[platformName]}
+            </Styled.PlatformName>
+            <Styled.Name>{name?.slice(0, 6)}</Styled.Name>
+          </Styled.ResultCardBackground>
+          <Styled.SparkleLeftTop />
+          <Styled.SparkleRightTop />
+          <Styled.SparkleLeftBottom />
+          <Styled.SparkleRightBottom />
+        </Styled.ResultCard>
+        <Styled.LinearGradientSphereWrapper>
+          <LinearGradientSphere platform={platformName} />
+        </Styled.LinearGradientSphereWrapper>
+      </Styled.ResultCardContainer>
+    );
+  },
+);
 
 ResultCard.displayName = 'ResultCard';
 export default ResultCard;

--- a/src/components/result/ResultCardSection/ResultCardSection.component.tsx
+++ b/src/components/result/ResultCardSection/ResultCardSection.component.tsx
@@ -1,5 +1,4 @@
 import { Button, ConfirmModalDialog } from '@/components/common';
-import { ResultCard } from '@/components/result';
 import { Platform, PLATFORM_NAME_MAP } from '@/constants/platform';
 import { useRef, useState } from 'react';
 import useDownloadElementToImage from '@/hooks/useDownloadElementToImage';
@@ -44,7 +43,7 @@ const ResultCardSection = ({ platformName }: ResultCardSectionProps) => {
     <>
       <Styled.ResultCardSection>
         <Styled.EffectText>연봉아 올라라{'\n'}내 직군 카드 완성!</Styled.EffectText>
-        <ResultCard platformName={platformName} ref={resultCardRef} />
+        <Styled.FadeUpResultCard platformName={platformName} ref={resultCardRef} />
         <Styled.SaveAndShareContainer>
           <Button size="l" isSelected={false} onClick={handleSaveImage}>
             카드 저장하기

--- a/src/components/result/ResultCardSection/ResultCardSection.styled.ts
+++ b/src/components/result/ResultCardSection/ResultCardSection.styled.ts
@@ -1,5 +1,6 @@
 import { css } from '@emotion/react';
 import styled from '@emotion/styled';
+import ResultCard from '../ResultCard/ResultCard.component';
 
 export const ResultCardSection = styled.section`
   display: flex;
@@ -11,6 +12,7 @@ export const ResultCardSection = styled.section`
 
 export const EffectText = styled.div`
   ${({ theme }) => css`
+    ${theme.animation.fadeUp({ duration: 0.8, move: 2 })};
     margin-bottom: 4rem;
     color: ${theme.color.white};
     font-weight: 700;
@@ -21,10 +23,20 @@ export const EffectText = styled.div`
   `}
 `;
 
+export const FadeUpResultCard = styled(ResultCard)`
+  ${({ theme }) => css`
+    ${theme.animation.fadeUp({ duration: 0.8, move: 4 })}
+  `}
+`;
+
 export const SaveAndShareContainer = styled.section`
-  display: grid;
-  grid-template-columns: 1fr 1fr;
-  width: 31.5rem;
-  margin: 4rem 0 0;
-  column-gap: 1.5rem;
+  ${({ theme }) => css`
+    ${theme.animation.fadeUp({ duration: 0.8, delay: 0.1, move: 4 })};
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    width: 31.5rem;
+    margin: 4rem 0 0;
+    column-gap: 1.5rem;
+    opacity: 0;
+  `}
 `;

--- a/src/styles/theme/animation.ts
+++ b/src/styles/theme/animation.ts
@@ -1,0 +1,46 @@
+import { css, keyframes } from '@emotion/react';
+
+interface fadeProps {
+  duration: number;
+  delay?: number;
+  move?: number; // rem단위 사용, 1rem = 10px
+}
+
+const fadeUp = ({ duration, delay = 0, move = 10 }: fadeProps) => {
+  const fadeUpAnimation = keyframes`
+  from {
+    opacity: 0;
+    transform: translate3d(0, ${move}rem, 0);
+  }
+  to {
+    opacity: 1;
+    transform: translate3d(0, 0, 0);
+  }
+`;
+
+  return css`
+    animation: ${fadeUpAnimation} ${duration}s ${delay}s ease-in-out forwards;
+  `;
+};
+
+const fadeIn = ({ duration, delay = 0 }: fadeProps) => {
+  const fadeUpAnimation = keyframes`
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+`;
+
+  return css`
+    animation: ${fadeUpAnimation} ${duration}s ${delay}s ease-in-out forwards;
+  `;
+};
+
+export const animation = {
+  fadeUp,
+  fadeIn,
+} as const;
+
+export type AnimationType = typeof animation;

--- a/src/styles/theme/index.ts
+++ b/src/styles/theme/index.ts
@@ -1,7 +1,9 @@
 import { color } from './color';
 import { zIndex } from './zIndex';
+import { animation } from './animation';
 
 export const theme = {
   color,
   zIndex,
+  animation,
 };


### PR DESCRIPTION
## 변경사항

- theme객체에 animation객체를 추가하여 animation을 theme객체에서 function으로 사용할 수 있도록 정의해주었습니다. 현재 animation객체에는 fadeIn, fadeUp 메서드가 구현되어 있습니다.
- generate페이지에서 다음 버튼을 누를시 약 2초간 카드가 만들어지는 인터렉션이 나온 후 result페이지로 router.push하도록 구현하였습니다.
- result페이지에 접근시 푸터를 제외한 모든 요소들에 fadeUp 인터렉션을 추가해주었습니다.
