### PR TITLE
generate -> result 페이지로 넘어가는 딜레이 증가

### DIFF
--- a/pages/generate/[platformName].tsx
+++ b/pages/generate/[platformName].tsx
@@ -48,7 +48,7 @@ const GeneratePage: NextPage<GeneratePageProps> = ({ platformName }) => {
     setIsGenerating(true);
     setTimeout(() => {
       router.push(`${RESULT_ROUTES[platformName]}?${selectedOptionParams}`);
-    }, 2000);
+    }, 2300);
   };
 
   const handleBackToPrevPage = () => {


### PR DESCRIPTION
## 변경사항

- generate -> result 페이지로 넘어가는 도중 인터렉션 노출 시간이 프로토타입보다 짧게 나와서 딜레이를 0.3s 늘려주었습니다.
